### PR TITLE
added command parser, updated command callback syntax

### DIFF
--- a/aph.js
+++ b/aph.js
@@ -1,6 +1,7 @@
 const difflib = require('difflib');
 const readline = require('readline');
 const fs = require('fs');
+const parseCommand = require ( './command-parser.js' );
 
 let title_art = `
   █████╗ ██████╗ ███╗ ███╗
@@ -55,7 +56,7 @@ let commands = {
   "forget" : () => { memory = {}; console.log ( "Memory cleared" ) },
   "clear" : () => consoleFresh(title_art),
   "shouldlearn" : () => { should_learn = !should_learn; console.log ( "Learning: " + bool_onoff [ should_learn ] ) },
-  "save" : filename => {
+  "save" : ( switches, filename ) => {
     if (filename) {
       fs.writeFileSync('saves/' + filename + '.json', JSON.stringify ( memory ), "utf8");
       console.log("Saved " + Object.keys ( memory ).length + " memory keys to " + filename + ".json")
@@ -64,7 +65,7 @@ let commands = {
       console.log("Saved " + Object.keys ( memory ).length + " memory keys to default save location (_default.json)")
     }
   },
-  "load" : filename => {
+  "load" : ( switches, filename ) => {
       if (filename) {
         memory = JSON.parse(fs.readFileSync('saves/' + filename + '.json', "utf8"));
         console.log("Loaded " + Object.keys ( memory ).length + " memory keys from " + filename + ".json")
@@ -96,7 +97,7 @@ let aliases = {
     "s": "save",
     "ld": "load",
     "sp": "setprefix",
-    "pre": "setprefix" 
+    "pre": "setprefix"
 }
 
 for ( const [ name, alias ] of Object.entries ( aliases ) ) {
@@ -123,7 +124,7 @@ function converse(user_input) {
       response = choice(memory[choice(difflib.getCloseMatches(user_input, Object.keys(memory), selection_range, 0))])
     }
   }
-  
+
   if (response) {
     // console.log('<RESPONSE>');
     return response;
@@ -143,12 +144,12 @@ const rl = readline.createInterface({
 rl.prompt()
 
 rl.on('line', (user_input) => {
-  let command, response;
+  let args, switches, response;
   if (user_input.startsWith(prefix)) {
-    command = user_input.slice(1).split ( " " );
-    if ( command [ 0 ] in commands ) {
+    { command, args, flags } = parseCommand ( user_input );
+    if ( command in commands ) {
       // console.log ( '<USER COMMAND>' );
-      response = commands [ command [ 0 ] ] ( ...command.slice ( 1 ) );
+      response = commands [ command ] ( flags, ...args );
       if ( response ) {
         console.log ( response );
       }

--- a/command-parser.js
+++ b/command-parser.js
@@ -29,6 +29,9 @@ export function parseCommand ( input ) {
                     }
 
                     if ( match = input.match ( argument ) ) {       // consume argument if one is available
+                        // unescape quotes
+                        match [ 0 ] = match [ 0 ].replace ( /\\"/g, '"' ).replace ( /\\'/g, "'" );
+
                         if ( current_flag ) {
                             result.flags [ current_flag ].push ( match [ 0 ] );
                         } else {

--- a/command-parser.js
+++ b/command-parser.js
@@ -1,4 +1,4 @@
-export function parseCommand ( input ) {
+module.exports = function parseCommand ( input ) {
     const   command = /^[a-zA-Z_$]+[a-zA-Z0-9_$-]*/,
             whitespace = /^\s+/,
             argument = /^"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|[^\s]+/,

--- a/command-parser.js
+++ b/command-parser.js
@@ -9,14 +9,14 @@ module.exports = function parseCommand ( input ) {
                 args: [],
                 flags: {}
             },
-            state = 'start',
+            current_state = 'start',
             current_flag = '',
             handleState = {
                 start: input => {
                     // consume command token
                     if ( match = input.match ( command ) ) {
                         result.command = match [ 0 ];
-                        state = 'args';
+                        current_state = 'args';
                         return input.slice ( match [ 0 ].length );
                     }
 
@@ -39,7 +39,7 @@ module.exports = function parseCommand ( input ) {
                         }
                         return input.slice ( match [ 0 ].length );
                     } else if ( input.startsWith ( '-' ) ) {
-                        state = 'flags';
+                        current_state = 'flags';
                         return input;
                     }
 
@@ -61,7 +61,7 @@ module.exports = function parseCommand ( input ) {
 
                         return input.slice ( match [ 0 ].length );
                     } else {
-                        state = 'args';
+                        current_state = 'args';
                         return input;
                     }
                 }
@@ -72,7 +72,7 @@ module.exports = function parseCommand ( input ) {
 
     // consume input, starting with command, then taking command args, then alternating between flags and flag args
     while ( input ) {
-        input = handleState ( input );
+        input = handleState [ current_state ] ( input );
     }
     return result;
 }

--- a/command-parser.js
+++ b/command-parser.js
@@ -1,0 +1,75 @@
+export function parseCommand ( input ) {
+    const   command = /^[a-zA-Z_$]+[a-zA-Z0-9_$-]*/,
+            whitespace = /^\s+/,
+            argument = /^"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|[^\s]+/,
+            flag = /^-([a-zA-Z_$]+[a-zA-Z0-9_$-]*)/,
+            match = null,
+            result = {
+                command: '',
+                args: [],
+                flags: {}
+            },
+            state = 'start',
+            current_flag = '',
+            handleState = {
+                start: input => {
+                    // consume command token
+                    if ( match = input.match ( command ) ) {
+                        result.command = match [ 0 ];
+                        state = 'args';
+                        return input.slice ( match [ 0 ].length );
+                    }
+
+                    throw new Error ( 'Command Parser: invalid command syntax "${match[0]}"' );
+                },
+                args: input => {
+                    // ignore whitespace
+                    if ( match = input.match ( whitespace ) ) {
+                        input = input.slice ( match [ 0 ].length );
+                    }
+
+                    if ( match = input.match ( argument ) ) {       // consume argument if one is available
+                        if ( current_flag ) {
+                            result.flags [ current_flag ].push ( match [ 0 ] );
+                        } else {
+                            result.args.push ( match [ 0 ] );
+                        }
+                        return input.slice ( match [ 0 ].length );
+                    } else if ( input.startsWith ( '-' ) ) {
+                        state = 'flags';
+                        return input;
+                    }
+
+                    throw new Error ( 'Command Parser: invalid argument syntax "${match[0]}"' );
+                },
+                flags: input => {
+                    // ignore whitespace
+                    if ( match = input.match ( whitespace ) ) {
+                        input = input.slice ( match [ 0 ].length );
+                    }
+
+                    if ( match = input.match ( flag ) ) {       // consume argument if one is available
+                        if ( match [ 1 ] in result.flags ) {
+                            throw new Error ( 'Command Parser: invalid repeated flag "${match[0]}"' );
+                        } else {
+                            current_flag = match [ 1 ];
+                            result.flags [ current_flag ] = [];
+                        }
+
+                        return input.slice ( match [ 0 ].length );
+                    } else {
+                        state = 'args';
+                        return input;
+                    }
+                }
+            };
+
+    // ignore command prefix
+    input = input.slice ( 1 );
+
+    // consume input, starting with command, then taking command args, then alternating between flags and flag args
+    while ( input ) {
+        input = handleState ( input );
+    }
+    return result;
+}


### PR DESCRIPTION
Check this out and see how it works.

Basically commands can now be entered with arguments as well as flags.

For example:
```
.somecommand a b c -flag0 d e f -flag1 g h i
```

issues `somecommand` with the argumens `a, b, c` and the flags `flag0, flag1` with respective arguments `d, e, f` and `g, h, i` for each flag.

When this is passed to the command callback the flags are sent as the first argument, followed by the command argument spread like so:
```
( flags, ...args ) => somecommand {
    // do something with flags.flag0, which is a [ "d", "e", "f" ] array of arguments to that flag
    // likewise for flags.flag1
    // args is an array in this case [ "a", "b", "c" ]
}
```

The `parseCommand ( input )` function takes the full input string ( e.g. ".somecommand a b c..." ) and returns an object:
```
{
    command: "somecommand",
    args: [ "a", "b", "c" ],
    flags: {
        flag0: [ "d", "e", "f" ],
        flag1: [ "g", "h", "i" ]
    }
}
```