### PR TITLE
fixed `val.pop() is not a function`, added package.json

### DIFF
--- a/default-commands.js
+++ b/default-commands.js
@@ -122,7 +122,7 @@ let commands = {
     } ],
 };
 
-for ( let [ key, val ] of Object.keys ( commands ) ) {
+for ( let [ key, val ] of Object.entries ( commands ) ) {
     let callback = val.pop ();
 
     for ( name in val ) {

--- a/default-commands.js
+++ b/default-commands.js
@@ -125,9 +125,9 @@ let commands = {
 for ( let [ key, val ] of Object.entries ( commands ) ) {
     let callback = val.pop ();
 
-    for ( name in val ) {
+    for ( name of val ) {
         if ( name in aliases ){
-            throw new Error ( "Duplicate aliases are not allowed" );
+            throw new Error ( "Duplicate aliases are not allowed: " + [ name, key ] );
         }
         aliases [ name ] = key;
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,48 @@
 {
-  "requires": true,
-  "lockfileVersion": 1,
-  "dependencies": {
-    "difflib": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/difflib/-/difflib-0.2.4.tgz",
-      "integrity": "sha1-teMDYabbAjF21WKJLbhZQKcY9H4=",
-      "requires": {
-        "heap": ">= 0.2.0"
-      }
+    "name": "Aph",
+    "version": "0.2.0",
+    "lockfileVersion": 2,
+    "requires": true,
+    "packages": {
+        "": {
+            "version": "0.2.0",
+            "license": "GPL3",
+            "dependencies": {
+                "difflib": "0.2.4"
+            },
+            "devDependencies": {},
+            "engines": {
+                "node": ">= 10.6.0",
+                "npm": ">= 6.1.0"
+            }
+        },
+        "node_modules/difflib": {
+            "version": "0.2.4",
+            "resolved": "https://registry.npmjs.org/difflib/-/difflib-0.2.4.tgz",
+            "integrity": "sha1-teMDYabbAjF21WKJLbhZQKcY9H4=",
+            "dependencies": {
+                "heap": ">= 0.2.0"
+            }
+        },
+        "node_modules/heap": {
+            "version": "0.2.6",
+            "resolved": "https://registry.npmjs.org/heap/-/heap-0.2.6.tgz",
+            "integrity": "sha1-CH4fELBGky/IWU3Z5tN4r8nR5aw="
+        }
     },
-    "heap": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/heap/-/heap-0.2.6.tgz",
-      "integrity": "sha1-CH4fELBGky/IWU3Z5tN4r8nR5aw="
+    "dependencies": {
+        "difflib": {
+            "version": "0.2.4",
+            "resolved": "https://registry.npmjs.org/difflib/-/difflib-0.2.4.tgz",
+            "integrity": "sha1-teMDYabbAjF21WKJLbhZQKcY9H4=",
+            "requires": {
+                "heap": ">= 0.2.0"
+            }
+        },
+        "heap": {
+            "version": "0.2.6",
+            "resolved": "https://registry.npmjs.org/heap/-/heap-0.2.6.tgz",
+            "integrity": "sha1-CH4fELBGky/IWU3Z5tN4r8nR5aw="
+        }
     }
-  }
 }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
     "description": "A difflib based chat bot. The name means Anthropomorphizing Parodist Heuristic bot (inspired by HAL 9000's definition)",
     "version": "0.2.0",
     "author": "Lukalot <https://github.com/Lukalot>",
+    "contributors": [
+        "Lukalot <https://github.com/Lukalot>",
+        "EricBalingit <https://github.com/EricBalingit>"
+    ],
     "repository": {
         "type": "git",
         "url": "https://github.com/Lukalot/Aph"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,33 @@
+{
+    "name": "Aph",
+    "description": "A difflib based chat bot. The name means Anthropomorphizing Parodist Heuristic bot (inspired by HAL 9000's definition)",
+    "version": "0.2.0",
+    "author": "Lukalot <https://github.com/Lukalot>",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/Lukalot/Aph"
+    },
+    "bugs": {
+        "type": "git",
+        "url": "https://github.com/Lukalot/Aph/issues"
+    },
+    "engines": {
+        "node": ">= 10.6.0",
+        "npm": ">= 6.1.0"
+    },
+    "main": "./main.js",
+    "keywords": [
+        "chatbot",
+        "difflib",
+        "python",
+        "python-javascript",
+        "javascript",
+        "js"
+    ],
+    "license": "GPL3",
+    "scripts": {},
+    "devDependencies": {},
+    "dependencies": {
+        "difflib": "0.2.4"
+    }
+}


### PR DESCRIPTION
With dependencies listed in `package.json`, users/contributors can run `npm install` in the Aph package directory to install dependencies locally.